### PR TITLE
feat: 페이지 refresh시 login 유지 및 logout 로직 추가

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,37 +5,36 @@ import PostList from "./page/postList/postList";
 import PostRegister from "./page/postRegister/postRegister";
 import Setting from "./page/setting/setting";
 import GithubLogin from "./page/auth/githubLogin";
-import { useCookies } from "react-cookie";
-import authService from "./service/auth_service";
 import { useDispatch, useSelector } from "react-redux";
-import { setUser } from "./store/user";
+import { fetchUserByRefreshToken } from "./store/user";
+
+/* 
+
+App component 
+
+로그인한 User 정보가 있으면 user 정보를 set 하고
+적절한 component로 routing을 진행합니다.
+
+react-cookie를 사용하려 했으나 refresnToken이 httpOnly라서
+일단은 큰 상관 없는걸로...
+
+*/
 
 function App() {
   const user = useSelector((state) => state.user);
-  const [cookies, setCookie, removeCookie] = useCookies(["R_AUTH"]);
   const dispatch = useDispatch();
 
   useEffect(() => {
     if (user.nickName !== undefined) {
+      // 유저가 존재하면 return
       console.log("user가 있어서 return합니다! user 정보 : ", user);
       return;
     }
-
-    authService.getUserInfo().then((user) => {
-      console.log(user.data.userNickName);
-      const userInfo = {
-        nickName: user.data.nickName,
-        id: user.data._id,
-      };
-      console.log(userInfo);
-      dispatch(setUser(userInfo));
+    dispatch(fetchUserByRefreshToken()).then((response) => {
+      // 유저 미존재시 refresh token을 이용해서 유저정보 얻어옴
+      console.log("fetchByuserRefreshToken response :", response);
+      // 실패했을때 에러처리 필요할 듯
     });
-    /*
-    if (cookies.rememberEmail !== undefined) {
-      setEmail(cookies.rememberEmail);
-      setIsRemember(true);
-    }
-    */
   }, [user, dispatch]);
 
   return (

--- a/client/src/component/dropdown_bar/dropdownBar.jsx
+++ b/client/src/component/dropdown_bar/dropdownBar.jsx
@@ -1,11 +1,25 @@
 import React from "react";
 import styles from "./dropdownBar.module.css";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
+import { clearUser } from "../../store/user";
+
+/* 
+
+로그인 한 유저에 대해서만 보이는 component로,
+닉네임, 작성 글, 찜한 글, 로그아웃으로 구성되어 있습니다.
+
+로그아웃의 경우 handleLogout을 통해 user를 초기화하는 과정을 진행하며
+API를 통해 refresh token을 초기화 합니다.
+
+*/
 
 const DropdownBar = () => {
   const user = useSelector((state) => state.user);
-
+  const dispatch = useDispatch();
+  const handleLogout = () => {
+    dispatch(clearUser());
+  };
   return (
     <div className={styles.menuWrapper}>
       <ul className={styles.menu}>
@@ -16,7 +30,9 @@ const DropdownBar = () => {
         <li className={styles.menuItem}>
           <Link to="/list">찜한 글</Link>
         </li>
-        <li className={styles.menuItem}>로그아웃</li>
+        <li className={styles.menuItem} onClick={handleLogout}>
+          로그아웃
+        </li>
       </ul>
     </div>
   );

--- a/client/src/component/login_user/loginUser.jsx
+++ b/client/src/component/login_user/loginUser.jsx
@@ -32,7 +32,7 @@ const LoginUser = () => {
 
   return (
     <div className={styles.userWrapper} onClick={handleLoginUserClick}>
-      <div className={styles.userName}>{user.name} 개발자</div>
+      <div className={styles.userName}>{user.nickName} 개발자</div>
       <img
         className={styles.userImg}
         src="https://media.vlpt.us/images/seeh_h/profile/6b7bfde5-b67c-4665-a2e1-a308e8de2059/tt.PNG?w=120"

--- a/client/src/component/modal/login_modal/loginModal.jsx
+++ b/client/src/component/modal/login_modal/loginModal.jsx
@@ -66,7 +66,7 @@ const SocialLogin = ({ handleLoginStep, handleClose }) => {
     const { tokenId } = response;
     console.log("#########token ID : ", tokenId);
     dispatch(fetchUserById(tokenId)).then((response) => {
-      console.log(response);
+      console.log("fetchByuserID response :", response);
       if (response.payload.loginSuccess === true) handleClose();
       else handleLoginStep();
     });

--- a/client/src/component/nav_bar/navbar.jsx
+++ b/client/src/component/nav_bar/navbar.jsx
@@ -9,7 +9,7 @@ import LoginUser from "../login_user/loginUser";
 const Navbar = (props) => {
   const [modalVisible, setModalVisible] = useState(false);
   const user = useSelector((state) => state.user);
-
+  console.log("user from navbar :", user);
   const openModal = () => {
     document.body.style.overflow = "hidden";
     setModalVisible(true);

--- a/client/src/service/auth_service.js
+++ b/client/src/service/auth_service.js
@@ -7,9 +7,21 @@ class Auth {
   }
 
   googleLogin = async (tokenId) => {
+    console.log("code: ", tokenId);
     try {
       const user = await this.auth.post("login/google", {
         tokenId,
+      });
+      return user;
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  githubLogin = async (code) => {
+    try {
+      const user = await this.auth.post("login/github", {
+        code,
       });
       return user;
     } catch (error) {

--- a/client/src/store/user.js
+++ b/client/src/store/user.js
@@ -6,6 +6,7 @@ const fetchUserById = createAsyncThunk(
   "user/fetchByIdStatus",
   async (userId, thunkAPI) => {
     const response = await authService.googleLogin(userId);
+    console.log("response received from auth API : ", response);
     const accessToken = response.data.accessToken;
 
     // header에 access token 설정
@@ -14,6 +15,25 @@ const fetchUserById = createAsyncThunk(
     ] = `Bearer ${accessToken}`;
 
     return response.data;
+  }
+);
+
+const fetchUserByRefreshToken = createAsyncThunk(
+  "user/fetchUserByRefreshToken",
+  async (thunkAPI) => {
+    const response = await authService.getUserInfo();
+    const accessToken = response.data.accessToken;
+    const userInfo = {
+      nickName: response.data.nickName,
+      id: response.data._id,
+    };
+
+    // header에 access token 설정
+    httpClient.defaults.headers.common[
+      "Authorization"
+    ] = `Bearer ${accessToken}`;
+
+    return userInfo;
   }
 );
 
@@ -27,18 +47,23 @@ const userSlice = createSlice({
     setUser: (state, action) => {
       state = action.payload;
     },
-    clearUser: (state, action) => {
-      state = null;
+    clearUser: (state) => {
+      state.nickName = undefined;
+      state.id = undefined;
     },
   },
   extraReducers: {
     [fetchUserById.fulfilled]: (state, { payload }) => {
-      state.nickName = payload.userNickName;
+      state.nickName = payload.nickName;
+      state.id = payload.nickName;
+    },
+
+    [fetchUserByRefreshToken.fulfilled]: (state, { payload }) => {
+      state.nickName = payload.nickName;
     },
   },
 });
 
 export const { setUser, clearUser } = userSlice.actions;
-export { fetchUserById };
-
+export { fetchUserById, fetchUserByRefreshToken };
 export default userSlice.reducer;


### PR DESCRIPTION
refresh시에 auth api로 요청을 보내 유저 정보를 받아 와서 로그인이 유지될 수 있도록 하였습니다.
로그아웃시 user 정보를 clear 해주었습니다. http only 설정이 되어있는 refresh token을 cookie에서 지우는 api 적용이 추가적으로 필요합니다.